### PR TITLE
delete development teams

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -110,22 +110,6 @@
             list:
                 [
                     {
-                        title: 'Development Teams',
-                        list:
-                            [
-                                {
-                                    name: 'BlockbeatHK',
-                                    link: '',
-                                    image: https://storage.googleapis.com/irisnet_asia_resources/irisnet.org/home/collaboration/blockbeathk.png
-                                },
-                                {
-                                    name: 'Tendermint',
-                                    link: 'https://tendermint.com/',
-                                    image: https://storage.googleapis.com/irisnet_asia_resources/irisnet.org/home/collaboration/tendermint.png
-                                }
-                            ]
-                    },
-                    {
                         title: 'Strategic Partners',
                         list:
                             [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed the "Development Teams" section from the "Collaboration" list in the README to streamline the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->